### PR TITLE
Fixed a bug where GetUrl wouldn't return a URL if the cookie file didn't exist

### DIFF
--- a/script.module.urlresolver/lib/urlresolver/plugins/lib/_megaupload.py
+++ b/script.module.urlresolver/lib/urlresolver/plugins/lib/_megaupload.py
@@ -279,7 +279,7 @@ def GetURL(url,cookiepath,enable_cookies=True):
     #print 'processing url: '+url
 
     # use cookie, if logged in.
-    if enable_cookies==True and cookiepath is not None os.path.exists(cookiepath):
+    if enable_cookies==True and cookiepath is not None and os.path.exists(cookiepath):
         cj = cookielib.LWPCookieJar()
         cj.load(cookiepath)
         req = urllib2.Request(url)

--- a/script.module.urlresolver/lib/urlresolver/plugins/lib/_megaupload.py
+++ b/script.module.urlresolver/lib/urlresolver/plugins/lib/_megaupload.py
@@ -279,27 +279,26 @@ def GetURL(url,cookiepath,enable_cookies=True):
     #print 'processing url: '+url
 
     # use cookie, if logged in.
-    if enable_cookies==True and cookiepath is not None:
-        if os.path.exists(cookiepath):
-            cj = cookielib.LWPCookieJar()
-            cj.load(cookiepath)
-            req = urllib2.Request(url)
-            req.add_header('User-Agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.3) Gecko/2008092417 Firefox/3.0.3')   
-            opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-            response = opener.open(req)
+    if enable_cookies==True and cookiepath is not None os.path.exists(cookiepath):
+        cj = cookielib.LWPCookieJar()
+        cj.load(cookiepath)
+        req = urllib2.Request(url)
+        req.add_header('User-Agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.3) Gecko/2008092417 Firefox/3.0.3')   
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+        response = opener.open(req)
 
-            #check if we might have been redirected (megapremium Direct Downloads...)
-            finalurl = response.geturl()
+        #check if we might have been redirected (megapremium Direct Downloads...)
+        finalurl = response.geturl()
 
-            #if we weren't redirected, return the page source
-            if finalurl is url:
-                link=response.read()
-                response.close()
-                return link
+        #if we weren't redirected, return the page source
+        if finalurl is url:
+            link=response.read()
+            response.close()
+            return link
 
-            #if we have been redirected, return the redirect url
-            elif finalurl is not url:               
-                return finalurl
+        #if we have been redirected, return the redirect url
+        elif finalurl is not url:               
+            return finalurl
 
     # don't use cookie, if not logged in        
     else:

--- a/script.module.urlresolver/lib/urlresolver/plugins/lib/megavideo.py
+++ b/script.module.urlresolver/lib/urlresolver/plugins/lib/megavideo.py
@@ -17,6 +17,26 @@
 import urllib2,re
 __version__ = "1.0.0"
 
+try:
+	if bin(0): pass
+except NameError, ne:
+	def bin(x):
+		'''
+		bin(number) -> string
+
+		Stringifies an int or long in base 2.
+		'''
+		if x < 0: return '-' + bin(-x)
+		out = []
+		if x == 0: out.append('0')
+		while x > 0:
+			out.append('01'[x & 1])
+			x >>= 1
+			pass
+		try: return '0b' + ''.join(reversed(out))
+		except NameError, ne2: out.reverse()
+		return '0b' + ''.join(out)
+
 class Megavideo:
 	URL = "http://www.megavideo.com/xml/videolink.php"
 


### PR DESCRIPTION
I couldn't watch any megaupload videos because I don't have an account there.
GetUrl is checking if the cookie file exists but if it doesn't exist, the method doesn't return anything.
Needs obviously to be tested with a premium account but I don't see any reason why it wouldn't work.
